### PR TITLE
fix(compiler): when useStorage returns a `Uint8Array`, decode it to text (fixes #33)

### DIFF
--- a/src/runtime/server/nitro/useCompiler.ts
+++ b/src/runtime/server/nitro/useCompiler.ts
@@ -11,14 +11,16 @@ export async function useCompiler(
   verbose = false,
 ) {
   const vueEmailOptions = useRuntimeConfig().public.vueEmail as ModuleOptions
-  const source = await useStorage(storageKey).getItem(filename)
+  let source = await useStorage(storageKey).getItem(filename)
+  if (source instanceof Uint8Array) source = new TextDecoder().decode(source)
   const keys = await useStorage(storageKey).getKeys()
   const components: {
     name: string
     source: string
   }[] = []
   for (const key of keys) {
-    const value = await useStorage(storageKey).getItem(key)
+    let value = await useStorage(storageKey).getItem(key)
+    if (value instanceof Uint8Array) value = new TextDecoder().decode(value)
 
     if (value && key.endsWith('.vue')) {
       components.push({

--- a/src/runtime/server/nitro/useCompiler.ts
+++ b/src/runtime/server/nitro/useCompiler.ts
@@ -12,7 +12,8 @@ export async function useCompiler(
 ) {
   const vueEmailOptions = useRuntimeConfig().public.vueEmail as ModuleOptions
   let source = await useStorage(storageKey).getItem(filename)
-  if (source instanceof Uint8Array) source = new TextDecoder().decode(source)
+  if (source instanceof Uint8Array)
+    source = new TextDecoder().decode(source)
   const keys = await useStorage(storageKey).getKeys()
   const components: {
     name: string
@@ -20,7 +21,8 @@ export async function useCompiler(
   }[] = []
   for (const key of keys) {
     let value = await useStorage(storageKey).getItem(key)
-    if (value instanceof Uint8Array) value = new TextDecoder().decode(value)
+    if (value instanceof Uint8Array)
+      value = new TextDecoder().decode(value)
 
     if (value && key.endsWith('.vue')) {
       components.push({


### PR DESCRIPTION
Addresses issue (#33) where when `useStorage.getItem` returns a `Uint8Array` instead of a string, which breaks server-side template compilation/rendering