### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,7 @@ Official Nuxt module for Vue Email. Build email templates with Vue components.
 1. Add `@vue-email/nuxt` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D @vue-email/nuxt
-
-# Using yarn
-yarn add --dev @vue-email/nuxt
-
-# Using npm
-npm install --save-dev @vue-email/nuxt
+npx nuxi@latest module add vue-email
 ```
 
 2. Add `@vue-email/nuxt` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
